### PR TITLE
バグを解消した

### DIFF
--- a/app/src/main/java/com/example/practicetodo/MainActivity.kt
+++ b/app/src/main/java/com/example/practicetodo/MainActivity.kt
@@ -83,8 +83,7 @@ class MainActivity : AppCompatActivity() {
     fun delete(id: String) {
         realm.executeTransaction {
             val task = realm.where(Task::class.java).equalTo("id", id).findFirst()
-                ?: return@executeTransaction
-            task.deleteFromRealm()
+            task?.deleteFromRealm()
         }
     }
 

--- a/app/src/main/java/com/example/practicetodo/RealmTodoApplication.kt
+++ b/app/src/main/java/com/example/practicetodo/RealmTodoApplication.kt
@@ -10,6 +10,7 @@ class RealmTodoApplication : Application() {
         Realm.init(this)
         val realmConfig = RealmConfiguration.Builder()
             .deleteRealmIfMigrationNeeded()
+            .allowWritesOnUiThread(true)
             .build()
         Realm.setDefaultConfiguration(realmConfig)
     }

--- a/app/src/main/java/com/example/practicetodo/TaskAdapter.kt
+++ b/app/src/main/java/com/example/practicetodo/TaskAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.recyclerview.widget.RecyclerView
@@ -43,10 +44,13 @@ class TaskAdapter(
     }
 
     class TaskViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val imageView: ImageView = view.imageView
-        val contentTextView: TextView = view.contentTextView
-        val dateTextView: TextView = view.dateTextView
+        val imageView: ImageView = view.findViewById(R.id.imageView)
+        val contentTextView: TextView = view.findViewById(R.id.contentTextView)
+        val dateTextView: TextView = view.findViewById(R.id.dateTextView)
+        val container: LinearLayout = view.findViewById(R.id.container)
     }
+
+
 
     interface OnItemClickListener {
         fun onItemClick(item: Task)


### PR DESCRIPTION
viewを参照できていない問題は、findViewByIdを用いてXMLの情報をひっぱてくる
TodoAdapter.kt 47行目

その後、RealmがUIセクションんでないと変更してはダメと言われたので、UIセクションでも許可をされるように設定した。
RealmTodoApplication.kt　13行目

ボタンを押した時に動作をしない問題があったから、？：でReturn文を書かずに、？を使ってNullになった時に実行しないように設定を行った。
MainActivity,kt 86行目